### PR TITLE
Support no std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 name = "subenum"
 
 [dev-dependencies]
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24.1", features = ["derive"], default-features = false }
 
 [dependencies]
 quote = "1.0.23"
@@ -26,5 +26,5 @@ proc-macro2 = "1.0.51"
 heck = "0.4.1"
 
 [features]
-default = ["std"]
+default = ["std", "strum/std"]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,6 @@ proc-macro2 = "1.0.51"
 heck = "0.4.1"
 
 [features]
-default = ["std", "strum/std"]
+default = ["std", "error_trait", "strum/std"]
 std = []
+error_trait = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 description = """A proc-macro to create subsets of enums, that can be converted
   to and from."""
 categories = ["development-tools::procedural-macro-helpers"]
-keywords = ["enum", "sub-enum"]
+keywords = ["enum", "sub-enum", "no-std"]
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ quote = "1.0.23"
 syn = { version = "1.0.107", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.51"
 heck = "0.4.1"
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -111,3 +111,10 @@ fn main() -> Result<(), TreeConvertError> {
 
 Bound lifetimes (e.g. `for<'a, 'b, 'c>`) are not currently supported. Please
 open a ticket if these are desired.
+
+# Features
+- `default` - `std` and `error_trait`
+- `std` - Use standard library collections and allocators within this proc macro
+- `error_trait` - Implement [`Error`](https://doc.rust-lang.org/std/error/trait.Error.html) for `*ConvertError` types.
+  - When combined with nightly and [`#![feature(error_in_core)]`](https://github.com/rust-lang/rust/issues/103765) supports `#[no_std]`
+  - Otherwise, this feature requires `std` as well.

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,3 +1,4 @@
+use std::vec::Vec;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{

--- a/src/build.rs
+++ b/src/build.rs
@@ -140,16 +140,16 @@ impl Enum {
             #[derive(Copy, Clone, Debug)]
             #vis struct #error;
 
-            impl std::fmt::Display for #error {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Debug::fmt(self, f)
+            impl core::fmt::Display for #error {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Debug::fmt(self, f)
                 }
             }
 
-            impl std::error::Error for #error {}
+            impl core::error::Error for #error {}
 
             #[automatically_derived]
-            impl #parent_impl std::convert::From<#child_ident #child_ty> for #parent_ident #parent_ty #parent_where {
+            impl #parent_impl core::convert::From<#child_ident #child_ty> for #parent_ident #parent_ty #parent_where {
                 fn from(child: #child_ident #child_ty) -> Self {
                     match child {
                         #(#from_child_arms),*
@@ -158,7 +158,7 @@ impl Enum {
             }
 
             #[automatically_derived]
-            impl #parent_impl std::convert::TryFrom<#parent_ident #parent_ty> for #child_ident #child_ty #parent_where {
+            impl #parent_impl core::convert::TryFrom<#parent_ident #parent_ty> for #child_ident #child_ty #parent_where {
                 type Error = #error;
 
                 fn try_from(parent: #parent_ident #parent_ty) -> Result<Self, Self::Error> {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -3,7 +3,7 @@ use syn::{Ident, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
 pub mod partial_eq;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub enum Derive {
     PartialEq,
 }

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::vec::Vec;
+use std::collections::{BTreeMap, BTreeSet};
 
 use syn::{punctuated::Punctuated, Generics, Ident, Token, TypeParamBound, Variant};
 
@@ -27,7 +28,7 @@ impl Enum {
     }
 
     pub fn compute_generics(&mut self, parent_generics: &Generics) {
-        let generic_bounds: HashMap<Param, Vec<TypeParamBound>> = parent_generics
+        let generic_bounds: BTreeMap<Param, Vec<TypeParamBound>> = parent_generics
             .type_params()
             .map(|param| {
                 (
@@ -95,8 +96,8 @@ impl Enum {
         // Extract all of the lifetimes and idents we care about from the types.
         let params = types.into_iter().flat_map(|ty| ty.extract_params());
 
-        // The same generic may appear in multiple bounds, so we use a HashSet to dedup.
-        let relevant_params: HashSet<Param> = params
+        // The same generic may appear in multiple bounds, so we use a BTreeSet to dedup.
+        let relevant_params: BTreeSet<Param> = params
             .flat_map(|param| param.find_relevant(&generic_bounds))
             .collect();
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,3 +1,6 @@
+use std::borrow::ToOwned;
+use std::boxed::Box;
+use std::vec::Vec;
 use syn::{Ident, Lifetime, Type, TypeParamBound};
 
 use crate::{iter::BoxedIter, param::Param};

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,3 +1,5 @@
+use std::boxed::Box;
+
 pub trait BoxedIter {
     type Item;
     fn boxed(self) -> Box<dyn Iterator<Item = Self::Item>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc as std;
 
 mod build;
 mod derive;
@@ -7,7 +14,9 @@ mod extractor;
 mod iter;
 mod param;
 
-use std::collections::HashMap;
+#[cfg(not(feature = "std"))]
+use std::{borrow::ToOwned, string::ToString, vec::Vec};
+use std::collections::BTreeMap;
 
 use derive::Derive;
 use heck::ToSnakeCase;
@@ -64,7 +73,7 @@ fn attribute_paths(attr: &Attribute) -> impl Iterator<Item = Path> {
     })
 }
 
-fn build_enum_map(args: AttributeArgs, derives: &[Derive]) -> HashMap<Ident, Enum> {
+fn build_enum_map(args: AttributeArgs, derives: &[Derive]) -> BTreeMap<Ident, Enum> {
     let err = "subenum must be called with a list of identifiers, like `#[subenum(EnumA, EnumB)]`";
     args.into_iter()
         .map(|nested| match nested {

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::vec::Vec;
+use std::collections::BTreeMap;
 
 use syn::{GenericParam, Generics, Ident, Lifetime, TypeParamBound, WherePredicate};
 
@@ -6,7 +7,7 @@ use crate::extractor::Extractor;
 
 /// A type or lifetime param, potentially used as a generic.
 /// E.g. the 'a in `'a: 'b + 'c` or the T in `T: U + V`.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Param {
     Lifetime(Lifetime),
     Ident(Ident),
@@ -42,7 +43,7 @@ impl Param {
     /// Example:
     /// Given `T` and bounds `T: U, U: V, V: W + X, W, X, Y: Z, Z`
     /// Will return `T, U, V, W, X`.
-    pub fn find_relevant(&self, bound_map: &HashMap<Param, Vec<TypeParamBound>>) -> Vec<Param> {
+    pub fn find_relevant(&self, bound_map: &BTreeMap<Param, Vec<TypeParamBound>>) -> Vec<Param> {
         match bound_map.get(self) {
             Some(bounds) => bounds
                 .iter()


### PR DESCRIPTION
- Add support for `#[no_std]`
- Support using `std` behind default `std` feature
- Feature gate `error_trait` impl `Error` for `*ConvertError`
  - Conditionally use `core::error::Error` if non-std (but this requires nightly)
- Document features in readme

Closes #14