### PR TITLE
Fix Missing Doc Warning for Error Struct

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -148,6 +148,7 @@ impl Enum {
 
             #(#inherited_derives)*
 
+            #[allow(missing_doc)]
             #[derive(Copy, Clone, Debug)]
             #vis struct #error;
 


### PR DESCRIPTION
Add attribute to error struct to allow for missing docs